### PR TITLE
Update secrets-store-csi-driver.yaml

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       serviceAccountName: csi-driver-registrar
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2


### PR DESCRIPTION
When using hostNetwork, by default you are not able to use Kubernetes services. This forces you to use Ingress, NodePort or an external Vault. 
Error log:
```
E1031 22:04:36.827357       1 utils.go:100] GRPC error: couldn't login: Post http://vault.vault.svc:8200/v1/auth/kubernetes/login: dial tcp: lookup vault.vault.s
vc on 172.20.0.2:53: no such host
```

It can be solved by changing the dnsPolicy. 
The following is noted in the Kubernetes documentation:
> “ClusterFirstWithHostNet“: For Pods running with hostNetwork, you should explicitly set its DNS policy “ClusterFirstWithHostNet”.
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy